### PR TITLE
Print help if no arguments passed

### DIFF
--- a/scylla.py
+++ b/scylla.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
 
     if args.help and not args.command or len(sys.argv) <= 1:
         parser.print_help()
-        exit
+        exit()
 
     logging.basicConfig(format='%(asctime)s,%(msecs)03d %(process)-7d %(name)-25s %(levelname)-8s | %(message)s')
     baselog.setLevel(logging.DEBUG if args.debug else logging.INFO)
@@ -152,7 +152,7 @@ if __name__ == '__main__':
 
     if args.list_api or args.list_modules or args.list_module_commands:
         list_api(scylla_api, args.list_modules, args.list_module_commands)
-        exit
+        exit()
 
     if args.command:
         command_name = args.command.strip(' /')


### PR DESCRIPTION
Currently there is no output in case of `./scylla.py`, let's print the `--help` in case of no arguments passed

```
beni@fedora ~/repos/scylla-cli (default_arg) $ ./scylla.py
usage: scylla.py [-h] [-a ADDRESS] [-p PORT] [-l] [--list-modules] [--list-module-commands LIST_MODULE_COMMANDS] [-d] [-t] [command] [command_args ...]

Scylla api command line interface.

positional arguments:
command               API command to invoke. module/command can be use to specify a command in a module
command_args          Optional arguments for the API command. Use `command -h` to print the command help message and exit

optional arguments:
-h, --help            Show this help message and exit
-a ADDRESS, --address ADDRESS
IP address of server node (default: localhost)
-p PORT, --port PORT  api port (default: 10000)
-l, --list            List all API commands
--list-modules        List all API modules
--list-module-commands LIST_MODULE_COMMANDS
List all commands in an API module
-d, --debug           Turn on debug logging (default=False)
-t, --test            Run test (default=False)
```