### PR TITLE
build out the rest client and use it for our rest calls

### DIFF
--- a/rest/__init__.py
+++ b/rest/__init__.py
@@ -1,5 +1,6 @@
+from typing import Optional
+
 import requests
-import json
 from logging import getLogger
 
 from requests import Response
@@ -43,33 +44,79 @@ class RestClient(object):
     def endpoint(self, value):
         self.__endpoint = value
 
-    def get(self, resource_path: str, additional_headers: dict = None) -> Response:
+    def get(self, resource_path: str, query_params: dict = None) -> Optional[Response]:
         """
         Sends a GET method request to the host resource specified
-        by the resource path. Returns a JSON type response and throws
+        by the resource path. Returns a Response type response and throws
         a ConnectionError in case of problems.
         :param resource_path: string with the path to the resource
-        :param additional_headers: a dict of headers to add to the
-        default ones
+        :param query_params: dict with params to add to the GET request
         :return: request response
-        :rtype: json
+        :rtype: Response
         """
         # construct request headers
         headers = {"Host": self.host,
                    "Content-Type": "application/json"}
 
         # add additional headers if needed
-        if additional_headers:
-            headers.update(additional_headers)
-
         logger.debug(f"Using headers: {headers}")
 
         # construct url string
-        url = f"{self.__url_prefix}{self.__host}:{self.port}{self.__endpoint}{resource_path}"
+        url = self.__construct_url(resource_path)
 
         logger.debug(f"Attempting a GET request for: {url}")
         try:
-            return requests.get(url=url, params=None, headers=headers)
+            return requests.get(url=url, params=query_params, headers=headers)
         except ConnectionError as details:
             logger.error(f"Connection error: {details}")
             return None
+
+    def post(self, resource_path: str, query_params: dict = None, json: dict = None) -> Response:
+        """
+        Sends a POST method request to the host resource specified
+        by the resource path. Returns a Response type response and throws
+        a ConnectionError in case of problems.
+        :param resource_path: string with the path to the resource
+        :param query_params: dict with params to add to the GET request
+        :param json: dict object to add as the POST methods json
+        :return: request response
+        :rtype: Response
+        """
+        # construct request headers
+        headers = {"Host": self.host,
+                   "Content-Type": "application/json"}
+
+        # add additional headers if needed
+        logger.debug(f"Using headers: {headers}")
+
+        # construct url string
+        url = self.__construct_url(resource_path)
+
+        logger.debug(f"Attempting a POST request for: {url}")
+        return requests.post(url=url, params=query_params, headers=headers, json=json)
+
+    def delete(self, resource_path: str, query_params: dict = None) -> Response:
+        """
+        Sends a DELETE method request to the host resource specified
+        by the resource path. Returns a Response type response and throws
+        a ConnectionError in case of problems.
+        :param resource_path: string with the path to the resource
+        :param query_params: dict with params to add to the GET request
+        :return: request response
+        :rtype: Response
+        """
+        # construct request headers
+        headers = {"Host": self.host,
+                   "Content-Type": "application/json"}
+
+        # add additional headers if needed
+        logger.debug(f"Using headers: {headers}")
+
+        # construct url string
+        url = self.__construct_url(resource_path)
+
+        logger.debug(f"Attempting a DELETE request for: {url}")
+        return requests.delete(url=url, params=query_params, headers=headers)
+
+    def __construct_url(self, resource_path: str) -> str:
+        return f"{self.__url_prefix}{self.__host}:{self.port}{self.__endpoint}{resource_path}"

--- a/rest/scylla_rest_client.py
+++ b/rest/scylla_rest_client.py
@@ -1,3 +1,5 @@
+from requests import Response
+
 from rest import RestClient
 
 
@@ -10,7 +12,22 @@ class ScyllaRestClient(RestClient):
             return api.json()
         return None
 
+    def get(self, resource_path: str, query_params: dict = None):
+        return super().get(resource_path=resource_path, query_params=query_params)
 
-if __name__ == "__main__":
-    client = ScyllaRestClient()
-    print(client.get_raw_api_json())
+    def post(self, resource_path: str, query_params: dict = None, json: dict = None):
+        return super().post(resource_path=resource_path, query_params=query_params, json=json)
+
+    def delete(self, resource_path: str, query_params: dict = None):
+        return super().delete(resource_path=resource_path, query_params=query_params)
+
+    def dispatch_rest_method(self, rest_method_kind: str, **kwargs) -> Response:
+        method_to_call_dict = {
+            "GET": self.get,
+            "POST": self.post,
+            "DELETE": self.delete
+        }
+
+        return method_to_call_dict[rest_method_kind](**kwargs)
+
+

--- a/scylla.py
+++ b/scylla.py
@@ -99,18 +99,19 @@ def test(node_address:str, port:int) -> ScyllaApi:
     return test_api
 
 # FIXME: better name
-def load_api(node_address:str, port:int) -> ScyllaApi:
-    scylla_api = ScyllaApi()
-    scylla_api.load(node_address, port)
+def load_api(node_address:str, port:str) -> ScyllaApi:
+    scylla_api = ScyllaApi(host=node_address, port=port)
+    scylla_api.load()
     return scylla_api
+
 
 if __name__ == '__main__':
     extra_args_help=f"[module/]command [{'|'.join(ScyllaApiCommand.Method.kind_to_str)}] [args...]"
     parser = ArgumentParser(description='Scylla api command line interface.', extra_args_help=extra_args_help)
     parser.add_argument(['-a', '--address'], dest='address', has_param=True,
-                        help=f"IP address of server node (default: {ScyllaApi.default_address})")
+                        help=f"IP address of server node (default: {ScyllaApi.DEFAULT_HOST})")
     parser.add_argument(['-p', '--port'], dest='port', has_param=True,
-                        help=f"api port (default: {ScyllaApi.default_port})")
+                        help=f"api port (default: {ScyllaApi.DEFAULT_PORT})")
 
     parser.add_argument(['-l', '--list'], dest='list_api', help=f"List all API commands")
     parser.add_argument('--list-modules', dest='list_modules', help=f"List all API modules")
@@ -130,8 +131,8 @@ if __name__ == '__main__':
 
     log.debug('Starting')
 
-    node_address = parser.get('address', ScyllaApi.default_address)
-    port = parser.get('port', ScyllaApi.default_port)
+    node_address = parser.get('address', ScyllaApi.DEFAULT_HOST)
+    port = parser.get('port', ScyllaApi.DEFAULT_PORT)
     if parser.get('test'):
         scylla_api = test(node_address=node_address, port=port)
     else:


### PR DESCRIPTION
- build out the RestClient base class and ScyllaResClient class to support get, post and delete methods
- initialize the ScyllaRestClient instance on CLI startup
- use the ScyllaRestClient for all our requests (both getting the raw API json and calls to the API server)
- add status code in front of the returned text message (should help, especially if the return for a POST or DELETE request is empty)

Tested locally with `./scylla.py column_family/autocompaction/{name} GET --name system:peers` (and variants: DELETE, POST , --help)