### PR TITLE
update python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='ScyllaDB',
     packages=find_packages(),
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=['requests'],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
Assignment expression := is introduced in Python 3.8
https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions
> scylla_api_client/rest/scylla_rest_client.py
> 13:        if api := self.get(resource_path):

PR changes minimum required python version.